### PR TITLE
fix: pass RNDIS MSOS descriptors to usbg_create_function

### DIFF
--- a/gc_rndis.c
+++ b/gc_rndis.c
@@ -38,7 +38,7 @@ int gc_rndis_create(int argc,char *argv[],gc_generic_info info)
             .sub_compatible_id = "5162001",
     };
 
-    usbg_ret = usbg_create_function(gadget,USBG_F_RNDIS,id,NULL,&f_rndis);
+    usbg_ret = usbg_create_function(gadget,USBG_F_RNDIS,id,&f_os_desc,&f_rndis);
     if(usbg_ret != USBG_SUCCESS){
         fprintf(stderr,"failed to create rndis function!  (maybe kernel module not loaded?) \n");
         gc_clean();


### PR DESCRIPTION
The gc_rndis_create function correctly defined the f_os_desc struct containing the RNDIS compatible_id for Windows, but it was not being passed to usbg_create_function (the argument was NULL).

This one-line change passes the &f_os_desc struct to the function, correctly applying the MSOS descriptors to the RNDIS function. This allows modern Windows to automatically recognize the RNDIS device without manual driver installation.